### PR TITLE
fix a small issue with 3scale readiness check

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -79,7 +79,7 @@ oc create secret generic rhsso-secret --from-literal=RHSSO_PWD=$RHSSO_PWD --from
 # Deploy 3scale Resources
 THREE_SCALE_URL=$(${DIR}/3scale.sh deploy)
 echo "Waiting for the ${THREE_SCALE_URL} to be reachable"
-wait_for "curl -s -o /dev/null -I -w '%{http_code}' ${THREE_SCALE_URL} | grep  -q 200" "3SCALE API to be reachable" "10m" "10"
+wait_for "curl -s -o /dev/null -w '%{http_code}' ${THREE_SCALE_URL} | grep 200" "3SCALE API to be reachable" "10m" "10"
 
 # Deploy the Workload App
 echo "Deploying the webapp with the following parameters:"


### PR DESCRIPTION
The problem is that 3scale check always fail even though the 3scale endpoint is working. The problem is that it needs to make a `GET` request, rather than just a `HEAD` request
* Remove the "-I" flag from the curl request and "-q" from `grep`