### PR TITLE
Fix wait for 3scale API using curl -f

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -79,7 +79,7 @@ oc create secret generic rhsso-secret --from-literal=RHSSO_PWD=$RHSSO_PWD --from
 # Deploy 3scale Resources
 THREE_SCALE_URL=$(${DIR}/3scale.sh deploy)
 echo "Waiting for the ${THREE_SCALE_URL} to be reachable"
-wait_for "curl -s -o /dev/null -I -w '%{http_code}' ${THREE_SCALE_URL} | grep  -q 200" "3SCALE API to be reachable" "10m" "10"
+wait_for "curl -s -o /dev/null -f  ${THREE_SCALE_URL}" "3SCALE API to be reachable" "10m" "10"
 
 # Deploy the Workload App
 echo "Deploying the webapp with the following parameters:"


### PR DESCRIPTION
**Why**

The `-I` option in curl will perform a HEAD request instead of a GET, and because the 3scale endpoint doesn't support HEAD requests it will respond with 404 forever.

```
-I, --head
              (HTTP  FTP  FILE) Fetch the headers only! HTTP-servers feature the command HEAD which this uses to get nothing but the header of a document. When used on an FTP or FILE
              file, curl displays the file size and last modification time only.
```

**How**

I have substituted the `-I` option with `-f` which will return the exit code 0 if the status code is not 200 otherwise it will return the exit code 22

```
       -f, --fail
              (HTTP) Fail silently (no output at all) on server errors. This is mostly done to better enable scripts etc to better deal with failed attempts. In normal cases when  an
              HTTP  server  fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This flag will prevent curl from outputting
              that and return error 22.
```
