### PR TITLE
fix: select correct 3scale admin API URL

### DIFF
--- a/deploy/3scale.sh
+++ b/deploy/3scale.sh
@@ -44,7 +44,7 @@ function jget() {
 function setup() {
     TOKEN="$(oc -n ${NAMESPACE} get secret system-seed -o jsonpath={.data.ADMIN_ACCESS_TOKEN} | base64 --decode)"
 
-    local host="$(oc -n ${NAMESPACE} get route -l zync.3scale.net/route-to=system-provider -o=jsonpath='{.items[0].spec.host}')"
+    local host="$(oc -n "${NAMESPACE}" get route -l zync.3scale.net/route-to=system-provider -o=json | jq -r '.items[].spec | select(.host|match("3scale-admin")) | .host')"
     API_URL="https://${host}/admin/api"
 
     log "API_URL=${API_URL}"


### PR DESCRIPTION
### Motivation

On PDS clusters, 3scale namespace contains multiple routes (every user has its own route), so selecting a first route as an admin route doesn't work here

I verified this change against both OSD and PDS clusters