### PR TITLE
revert replicas to 1

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -8,7 +8,7 @@ objects:
     metadata:
       name: workload-web-app
     spec:
-      replicas: 2
+      replicas: 1
       selector:
         app: workload-web-app
         deploymentconfig: workload-web-app
@@ -93,7 +93,7 @@ objects:
     metadata:
       name: workload-web-app-pdb
     spec:
-      minAvailable: 2
+      minAvailable: 1
       selector:
         matchLabels:
           app: workload-web-app


### PR DESCRIPTION
**What**
RHMI deploy template was reverted from 2 to 1 replicas. 
2 is required for HA testing on Managed Api but not required for 2.X.
1 is sufficient. 

**Verify**
Deploy the workload-web-app on a cluster with rhmi installed. 
Verify after 30 mins, the workload-web-app is not reporting any errors