### PR TITLE
Fix ns names in RHOAM

### DIFF
--- a/deploy/3scale.sh
+++ b/deploy/3scale.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 SCRIPT="3scale.sh"
 TOKEN=
 API_URL=
-NAMESPACE=${THREESCALE_NAMESPACE:-"redhat-rhmi-3scale"}
+if [[ -z "${RHOAM}" ]]; then
+  NAMESPACE=${THREESCALE_NAMESPACE:-"redhat-rhmi-3scale"}
+else
+  NAMESPACE=${THREESCALE_NAMESPACE:-"redhat-rhoam-3scale"}
+fi
 
 function log() {
     # always log to stderr to avoid interfiring with the stdout

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -3,8 +3,10 @@
 NS=${NAMESPACE:-"workload-web-app"}
 if [[ -z "${RHOAM}" ]]; then
   AMQONLINE_NS=${AMQONLINE_NAMESPACE:-"redhat-rhmi-amq-online"}
+  USERSSO_NS=${USERSSO_NAMESPACE:-"redhat-rhmi-user-sso"}
+else
+  USERSSO_NS=${USERSSO_NAMESPACE:-"redhat-rhoam-user-sso"}
 fi
-USERSSO_NS=${USERSSO_NAMESPACE:-"redhat-rhmi-user-sso"}
 IMAGE="quay.io/integreatly/workload-web-app:master"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CUSTOMER_ADMIN="customer-admin01"

--- a/deploy/template-rhoam.yaml
+++ b/deploy/template-rhoam.yaml
@@ -176,7 +176,7 @@ objects:
     subjects:
       - kind: ServiceAccount
         name: rhmi-operator
-        namespace: redhat-rhmi-operator
+        namespace: redhat-rhoam-operator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role


### PR DESCRIPTION
This PR fixes:
- names of the 3Scale and User SSO namespaces in RHOAM
- name of the namespace where RHOAM operator is running