### PR TITLE
Fix REQUEST_INTERVAL env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func init() {
 		log.SetLevel(log.DebugLevel)
 	}
 	if os.Getenv(envVarRequestInterval) != "" {
-		if val, err := strconv.Atoi(os.Getenv(envVarRequestInterval)); err != nil {
+		if val, err := strconv.Atoi(os.Getenv(envVarRequestInterval)); err == nil {
 			counters.RequestInterval = time.Duration(val) * time.Second
 		}
 	}


### PR DESCRIPTION
Fixes a logical bug, the code inside of the condition should be executed when there is no error.
Before the fix, env var was ignored.