### PR TITLE
apply-dashboards-observability-ns

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+OBSERVABILITY_NS="redhat-rhoam-observability"
 NS=${NAMESPACE:-"workload-web-app"}
 if [[ -z "${RHOAM}" ]]; then
   AMQONLINE_NS=${AMQONLINE_NAMESPACE:-"redhat-rhmi-amq-online"}
@@ -136,8 +137,8 @@ oc wait -n $NS --for="condition=Ready" pod -l app=workload-web-app --timeout=120
 if [[ ! -z "${GRAFANA_DASHBOARD}" ]]; then
   echo "Creating Grafana Dashboard for the app"
   if [[ -z "${RHOAM}" ]]; then
-    oc apply -n $NS -f $DIR/dashboard.yaml
+    oc apply -n $OBSERVABILITY_NS -f $DIR/dashboard.yaml
   else
-    oc apply -n $NS -f $DIR/dashboard-rhoam.yaml
+    oc apply -n $OBSERVABILITY_NS -f $DIR/dashboard-rhoam.yaml
   fi
 fi

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -137,7 +137,7 @@ oc wait -n $NS --for="condition=Ready" pod -l app=workload-web-app --timeout=120
 if [[ ! -z "${GRAFANA_DASHBOARD}" ]]; then
   echo "Creating Grafana Dashboard for the app"
   if [[ -z "${RHOAM}" ]]; then
-    oc apply -n $OBSERVABILITY_NS -f $DIR/dashboard.yaml
+    oc apply -n $NS -f $DIR/dashboard.yaml
   else
     oc apply -n $OBSERVABILITY_NS -f $DIR/dashboard-rhoam.yaml
   fi

--- a/deploy/undeploy.sh
+++ b/deploy/undeploy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+OBSERVABILITY_NS="redhat-rhoam-observability"
 NS=${NAMESPACE:-"workload-web-app"}
 if [[ -z "${RHOAM}" ]]; then
   AMQONLINE_NS=${AMQONLINE_NAMESPACE:-"redhat-rhmi-amq-online"}
@@ -8,6 +9,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Clean the Workload App
 oc delete all -l app=workload-web-app -n $NS
+oc delete grafanadashboards.integreatly.org workload-web-app -n $OBSERVABILITY_NS
 
 # if RHOAM flag passed ignore amq
 if [[ -z "${RHOAM}" ]]; then


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/MGDAPI-1885
The observability operator prometheus is namespace scoped so dashboards have to be created in the same namespace as prometheus. 

## How 
Change the Namespace in the deploy script

## Verification

1. deploy the oo-install branch
2. Set the following environment variables:
   ```bash
   export RHOAM=true
   # This env var is optional. Only set it if you want to view the metrics data using the Grafana dashboard
   export GRAFANA_DASHBOARD=true

   ```
3. Then run this command to deploy the app:
   ```make local/deploy```
4. Confirm that the two workload-web-app dashboards are available in the OO Grafana instance