### PR TITLE
MGDAPI-2333 Workload Web App not 100% reliable when measuring downtimes

### DIFF
--- a/deploy/template-rhoam.yaml
+++ b/deploy/template-rhoam.yaml
@@ -19,6 +19,21 @@ objects:
             deploymentconfig: workload-web-app
           annotations:
         spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: workload-web-app
+                  topologyKey: topology.kubernetes.io/zone
+                weight: 100
+              - podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: workload-web-app
+                  topologyKey: kubernetes.io/hostname
+                weight: 100
           containers:
             - name: workload-web-app
               image: ${WORKLOAD_WEB_APP_IMAGE}

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -8,7 +8,7 @@ objects:
     metadata:
       name: workload-web-app
     spec:
-      replicas: 1
+      replicas: 2
       selector:
         app: workload-web-app
         deploymentconfig: workload-web-app
@@ -19,6 +19,21 @@ objects:
             deploymentconfig: workload-web-app
           annotations:
         spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: workload-web-app
+                  topologyKey: topology.kubernetes.io/zone
+                weight: 100
+              - podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: workload-web-app
+                  topologyKey: kubernetes.io/hostname
+                weight: 100
           containers:
             - name: workload-web-app
               image: ${WORKLOAD_WEB_APP_IMAGE}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2333
Workload Web App not 100% reliable when measuring downtimes.

# What
podAntiAffinity was added, so pods are running now on different nodes.
It should improve HA


# Verification steps
Deploy application
Check that there are 2 replicas, and pods are running on different nodes