### PR TITLE
Use policy/v1 instead of v1beta1

### DIFF
--- a/deploy/template-rhoam.yaml
+++ b/deploy/template-rhoam.yaml
@@ -98,7 +98,7 @@ objects:
         deploymentconfig: workload-web-app
       sessionAffinity: None
   - kind: PodDisruptionBudget
-    apiVersion: policy/v1beta1
+    apiVersion: policy/v1
     metadata:
       name: workload-web-app-pdb
     spec:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,7 +104,7 @@ objects:
         deploymentconfig: workload-web-app
       sessionAffinity: None
   - kind: PodDisruptionBudget
-    apiVersion: policy/v1beta1
+    apiVersion: policy/v1
     metadata:
       name: workload-web-app-pdb
     spec:


### PR DESCRIPTION
Verification Steps

Deploy on a cluster (pull this PR and follow the readme). It should work as expected. Search for PodDisruptionBudget CR with name workload-web-app-pdb. The v1 apiVersion should be used.