### PR TITLE
Small updates to allow for podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-BUILD_TARGET=workload-app
-NAMESPACE=workload-web-app
-CONTAINER_ENGINE=docker
-CONTAINER_PLATFORM ?= linux/amd64
-TOOLS_IMAGE=quay.io/integreatly/workload-web-app-tools
+BUILD_TARGET?=workload-app
+NAMESPACE?=workload-web-app
+CONTAINER_ENGINE?=docker
+CONTAINER_PLATFORM?=linux/amd64
+TOOLS_IMAGE?=quay.io/integreatly/workload-web-app-tools
 WORKLOAD_WEB_APP_IMAGE?= # Alternative image 
 KUBECONFIG?=${HOME}/.kube/config
+ADDITIONAL_CONTAINER_ENGINE_PARAMS?=
 
-in_container = ${CONTAINER_ENGINE} run --rm -it \
+in_container = ${CONTAINER_ENGINE} run --rm -it ${ADDITIONAL_CONTAINER_ENGINE_PARAMS} \
 	-e KUBECONFIG=/kube.config \
 	-e SANDBOX=${SANDBOX} \
 	-e GRAFANA_DASHBOARD=${GRAFANA_DASHBOARD} \

--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ make local/undeploy
 
 Note: It might take up to 15 minutes for 3scale to fully remove the service (Product) hence you need to wait this long after undeploy if you want to deploy the workload-web-app again. In case the service is not fully removed yet the deployment fails with `System name has already been taken` error.
 
+## Troubleshooting
+
+In case of `make: stat: Makefile: Permission denied` error try to use privileged:
+
+```
+ADDITIONAL_CONTAINER_ENGINE_PARAMS="--privileged" CONTAINER_ENGINE=podman make local/deploy
+```
+


### PR DESCRIPTION
Small updates to allow for podman. What was done:
- using `?=` instead of `=` to actually allow the VARs to be overridden
- adding ADDITIONAL_CONTAINER_ENGINE_PARAMS to allow for adding an extra params if needed. On my machine if using podman I has to use `--privileged` for instance
- added Troubleshooting section to readme

### Verification

Have a cluster and try that command from the readme. Inspect the output so see that `--privileged` and `podman` (rather than docker) were indeed used.