### PR TITLE
MGDAPI-5762 - move wwa dashboard to another namespace

### DIFF
--- a/deploy/dashboard-rhoam.yaml
+++ b/deploy/dashboard-rhoam.yaml
@@ -3,7 +3,7 @@ kind: GrafanaDashboard
 metadata:
   name: workload-web-app
   labels:
-    monitoring-key: middleware
+    monitoring-key: customer
 spec:
   json: |
     {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-OBSERVABILITY_NS="redhat-rhoam-observability"
+OBSERVABILITY_NS="redhat-rhoam-customer-monitoring-operator"
 NS=${NAMESPACE:-"workload-web-app"}
 
 if [[ -z "${SANDBOX}" ]]; then
   SSO_NS=${USERSSO_NAMESPACE:-"redhat-rhoam-user-sso"}
 else
   SSO_NS=${USERSSO_NAMESPACE:-"sandbox-rhoam-rhsso"}
-  OBSERVABILITY_NS="sandbox-rhoam-observability"
+  OBSERVABILITY_NS="sandbox-rhoam-customer-monitoring-operator"
 fi
 
 IMAGE="quay.io/integreatly/workload-web-app:master"

--- a/deploy/template-rhoam.yaml
+++ b/deploy/template-rhoam.yaml
@@ -125,7 +125,7 @@ objects:
     metadata:
       name: workload-web-app
       labels:
-        monitoring-key: middleware
+        monitoring-key: customer
     spec:
       endpoints:
         - port: http

--- a/deploy/undeploy.sh
+++ b/deploy/undeploy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-OBSERVABILITY_NS="redhat-rhoam-observability"
+OBSERVABILITY_NS="redhat-rhoam-customer-monitoring-operator"
 if [[ -n "${SANDBOX}" ]]; then
-    OBSERVABILITY_NS="sandbox-rhoam-observability"
+    OBSERVABILITY_NS="sandbox-rhoam-customer-monitoring-operator"
 fi
 
 NS=${NAMESPACE:-"workload-web-app"}


### PR DESCRIPTION
## Issue
[MGDAPI-5762](https://issues.redhat.com/browse/MGDAPI-5762)

## What
Move workload-web-app dashboard from `redhat-rhoam-observability` namespace to `redhat-rhoam-customer-monitoring-operator` namespace

## Verification steps

1. Provision a cluster
2. Checkout this PR
3. Install RHOAM
4. Deploy the Workload App on the cluster
4.1 Login to the RHOAM cluster using `oc login` command
4.2 Set `export GRAFANA_DASHBOARD=true` 
4.3 Run this command to deploy the app: `make local/deploy`

5. Check if the workload-web-app is in the `redhat-rhoam-customer-monitoring-operator` namespace
5.1 In the OSD UI navigate to the `redhat-rhoam-customer-monitoring-operator` project
5.2 On the left hand side choose Networking -> Routes -> `grafana-route` location URL
5.3 Click on dashboards icon and choose Manage
5.4 Go to the `Workload App` folder and make sure it works.

6. Review the changes
7. Uninstall RHOAM and cleanup/delete the cluster
