### PR TITLE
MGDAPI-5928 Changed ServiceMonitor to monitoring.rhobs/v1 for OBO

### DIFF
--- a/deploy/template-rhoam.yaml
+++ b/deploy/template-rhoam.yaml
@@ -120,7 +120,7 @@ objects:
       kind: Role
       apiGroup: rbac.authorization.k8s.io
       name: workload-web-app
-  - apiVersion: monitoring.coreos.com/v1
+  - apiVersion: monitoring.rhobs/v1
     kind: ServiceMonitor
     metadata:
       name: workload-web-app


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-5928](https://issues.redhat.com/browse/MGDAPI-5928)

# What
This PR updates the `workload-web-app` ServiceMonitor to be of type `monitoring.rhobs/v1` instead of `monitoring.coreos.com/v1` so it can be consumed by the OBO Prometheus instance.

# Verification Steps

1. Provision a cluster
2. Install RHOAM using the OBO [feature branch](https://github.com/integr8ly/integreatly-operator/tree/mgdapi-5727-obo)
3. Wait for the installation to complete
4. Checkout this PR
5. Deploy the workload web app to the cluster and confirm that the `Workload App` dashboard contains data.