### PR TITLE
Update oc in Dockerfile.tools

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -5,7 +5,7 @@ RUN update-ca-trust extract
 
 RUN yum -y install make jq perl-XML-XPath
 
-ENV OC_VERSION="4.9.21"
+ENV OC_VERSION="4.12.29"
 RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$OC_VERSION/openshift-client-linux.tar.gz | tar -zx && \
     mv oc /usr/local/bin
 


### PR DESCRIPTION
Update oc in Dockerfile.tools to 4.12.29 which is current default version in OCM

Verification Steps

podman build --file ./Dockerfile.tools .
podman run --rm -it --entrypoint=/bin/bash sha-of-image-built-in-previous-step
oc version