### PR TITLE
Updated apiVersion for Template

### DIFF
--- a/deploy/template-rhoam.yaml
+++ b/deploy/template-rhoam.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: workload-web-app
 objects:


### PR DESCRIPTION
Updated apiVersion for Template. This should make the workload-web-app work on OCP/OSD v4.14

Verification Steps

In theory one has to deploy on both OSD v4.12 and OSD v4.14 to fully validate this. However, it might be sufficient just to do eye review since the change is quite simple.