### PR TITLE
MGDAPI-6953 set the default engine to docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 BUILD_TARGET?=workload-app
 NAMESPACE?=workload-web-app
 
-# Auto-detect container engine if not specified
-CONTAINER_ENGINE?=$(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
+# Default to Docker for CI/CD compatibility, but allow override
+CONTAINER_ENGINE?=docker
 
 CONTAINER_PLATFORM?=linux/amd64
 TOOLS_IMAGE?=quay.io/integreatly/workload-web-app-tools

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ A test app for simulating the workload on the openshift cluster based on end-use
 
 ## Container Engine Support
 
-This application supports both **Docker** and **Podman**. The Makefile automatically detects which container engine is available:
+This application supports both **Docker** and **Podman**. The Makefile defaults to Docker for CI/CD compatibility:
 
-- If Podman is available, it uses Podman
-- If only Docker is available, it uses Docker
-- You can override the detection by setting `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman`
+- Docker is used by default
+- You can override to use Podman by setting `CONTAINER_ENGINE=podman`
+- You can explicitly specify Docker with `CONTAINER_ENGINE=docker`
 
 ### Check your container engine
 

--- a/check-container-engine.sh
+++ b/check-container-engine.sh
@@ -31,8 +31,8 @@ echo ""
 # Determine which engine would be used
 if [ "$DOCKER_AVAILABLE" = true ] && [ "$PODMAN_AVAILABLE" = true ]; then
     echo "🎯 Both container engines are available!"
-    echo "   The Makefile will automatically use: Podman (preferred)"
-    echo "   To use Docker instead: CONTAINER_ENGINE=docker make <target>"
+    echo "   The Makefile will automatically use: Docker (default)"
+    echo "   To use Podman instead: CONTAINER_ENGINE=podman make <target>"
 elif [ "$PODMAN_AVAILABLE" = true ]; then
     echo "🎯 Only Podman is available - it will be used automatically"
 elif [ "$DOCKER_AVAILABLE" = true ]; then


### PR DESCRIPTION
## What
set the default engine version to docker
MGDAPI-6953

## Verification
- checkout this branch
- On a cluster with rhoam installed deploy the workload-web-app and note that its using docker by default
```bash
make local/deploy  
✓ docker is available
docker build --platform=linux/amd64 -t quay.io/integreatly/workload-web-app-tools -f Dockerfile.tools .
[+] Building 0.9s (11/11) FINISHED                                                                            docker:default
 => [internal] load build definition from Dockerfile.tools                                                              0.1s
 => => transferring dockerfile: 641B                                                                                    0.0s
 => [internal] load metadata for registry.redhat.io/ubi9/ubi:9.4                                                        0.4s
 => [internal] load .dockerignore                                                                                       0.1s
 => => transferring context: 2B                                                                                         0.0s
 => [internal] load build context                                                                                       0.1s
 => => transferring context: 195B                                                                                       0.0s
 => [1/6] FROM registry.redhat.io/ubi9/ubi:9.4@sha256:ee0b908e958a1822afc57e5d386d1ea128eebe492cb2e01b6903ee19c133ea75  0.0s
 => CACHED [2/6] COPY resources/rhit-root-ca.crt /etc/pki/ca-trust/source/anchors/                                      0.0s
 => CACHED [3/6] RUN update-ca-trust extract                                                                            0.0s
 => CACHED [4/6] RUN dnf install -y make gcc &&     dnf clean all                                                       0.0s
 => CACHED [5/6] RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.17.2/openshift-client  0.0s
 => CACHED [6/6] RUN curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 &  0.0s
 => exporting to image                                                                                                  0.0s
 => => exporting layers                                                                                                 0.0s
 => => writing image sha256:1756675c5f6a6a03ee6291f7d620f26551b6e7435e5d95ab9ec21deadad79f6e                            0.0s
 => => naming to quay.io/integreatly/workload-web-app-tools                                                             0.0s
docker run --rm -it  -e KUBECONFIG=/kube.config -e RHOAMI= -e GRAFANA_DASHBOARD= -e USERSSO_NAMESPACE= -e THREESCALE_NAMESPACE= -e WORKLOAD_WEB_APP_IMAGE= -v /home/austincunningham/.kube/config:/kube.config:z -v "/home/austincunningham/repo/workload-web-app":/workload-web-app -w /workload-web-app quay.io/integreatly/workload-web-app-tools make deploy
./deploy/deploy.sh
Already on project "workload-web-app" on server "https://api.austin-ccs.xcbd.s1.devshift.org:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app rails-postgresql-example

to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname

namespace/workload-web-app labeled
Error from server (NotFound): routes.route.openshift.io "keycloak-edge" not found
Ignoring missing "keycloak-edge" route and using route "keycloak" instead
secret/rhsso-secret created
3scale.sh: API_URL=https://3scale-admin.apps.austin-ccs.xcbd.s1.devshift.org/admin/api
3scale.sh: create workload-app-api-account
3scale.sh: create workload-app-api-backend
3scale.sh: create workload-app-api-metric in backend=4
3scale.sh: create mapping_rule with backend_id=4 and metric_id=12
3scale.sh: create workload-app-api service
3scale.sh: error: xget: failed to find '//service/id/text()' in: '<?xml version="1.0" encoding="UTF-8"?><errors><error>System name has already been taken</error></errors>'
3scale.sh: create backend_usage with service_id= and backend_id=4
3scale.sh: create workload-app-api-plan in service=
3scale.sh: error: xget: failed to find '//plan/id/text()' in: '<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>Not Found</title>
    <link href="/assets/error.css" media="screen" rel="stylesheet" type="text/css" />
  </head>

  <body>
    <div id="wrapper">
      <div id="content">
        <h1 class='logo-3scale logo-3scale--svg logo-3scale--boxed' id="logo">
          3scale
        </h1>

        <h1>Not Found</h1>
        <p>Sorry. We can't find what you're looking for.</p>
      </div>

      <div id="footer">
        <div class="powered-by-3scale last">
          <a href="http://www.3scale.net" target="_blank">
            Powered by <span class="logo-3scale logo-3scale--svg logo-3scale--powered">3scale</span>
          </a>
        </div>
      </div>
    </div>
  </body>
</html>'
3scale.sh: create workload-app-api-app in account=5 with plan_id=
3scale.sh: error: xget: failed to find '//application/user_key/text()' in: ''
Waiting for the  to be reachable
Waiting for 3SCALE API to be reachable for 10m...
curl: no URL specified!
curl: try 'curl --help' for more information
Waiting for 3SCALE API to be reachable... Trying again in 10s
...
3SCALE API to be reachable finished!
Deploying the webapp with the following parameters:
RHSSO_SERVER_URL=https://keycloak-redhat-rhoam-user-sso.apps.austin-ccs.xcbd.s1.devshift.org
THREE_SCALE_URL=
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
deploymentconfig.apps.openshift.io/workload-web-app created
service/workload-web-app created
poddisruptionbudget.policy/workload-web-app-pdb created
serviceaccount/workload-web-app created
role.rbac.authorization.k8s.io/workload-web-app created
rolebinding.rbac.authorization.k8s.io/workload-web-app created
servicemonitor.monitoring.rhobs/workload-web-app created
role.rbac.authorization.k8s.io/rhmi-prometheus-k8s created
rolebinding.rbac.authorization.k8s.io/rhmi-prometheus-k8s created
role.rbac.authorization.k8s.io/rhmi-operator created
rolebinding.rbac.authorization.k8s.io/rhmi-operator created
Waiting for pods to be ready
pod/workload-web-app-1-h6kp6 condition met
pod/workload-web-app-1-tzlj9 condition met
``` 
