### PR TITLE
MGDAPI-6955 Fix broken podman build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ KUBECONFIG?=${HOME}/.kube/config
 
 # Podman-specific parameters for better compatibility
 ifeq ($(CONTAINER_ENGINE),podman)
-    ADDITIONAL_CONTAINER_ENGINE_PARAMS?=--userns=keep-id
+    ADDITIONAL_CONTAINER_ENGINE_PARAMS?=--privileged
 else
     ADDITIONAL_CONTAINER_ENGINE_PARAMS?=
 endif


### PR DESCRIPTION
# what
MGDAPI-6955
fix broken podman build 

# Verification
- On a cluster with rhoam installed install the workload-web-app with podman
```bash
CONTAINER_ENGINE=podman make local/deploy
✓ podman is available
podman build --platform=linux/amd64 -t quay.io/integreatly/workload-web-app-tools -f Dockerfile.tools .
WARN[0000] The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message. 
STEP 1/8: FROM registry.redhat.io/ubi9/ubi:9.4
STEP 2/8: COPY resources/rhit-root-ca.crt /etc/pki/ca-trust/source/anchors/
--> Using cache 50985eeb599462829fe1ad9b598859345adb16987f01e08f3b3c7275544b5bba
--> 50985eeb5994
STEP 3/8: RUN update-ca-trust extract
--> Using cache 1ab35ea324018d1be388c042fac8d3ffd5562fd9127250b68766e05ca0cb58eb
--> 1ab35ea32401
STEP 4/8: RUN dnf install -y make gcc &&     dnf clean all
--> Using cache 162b856aaa791006fed798d8bae2176a1b5adf6ee4a1d3e171bd8040227485c6
--> 162b856aaa79
STEP 5/8: ENV OC_VERSION="4.17.2"
--> Using cache 7df563f82b68689d8511ee1a84a141cb3ec89c6b6ff657e0b29a89a47238c60d
--> 7df563f82b68
STEP 6/8: RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$OC_VERSION/openshift-client-linux.tar.gz | tar -zx &&     mv oc /usr/local/bin
--> Using cache 5ba44f079f60b9b364d6243670a3adce6a1052f9e1e4cb3ba974c2ef9ad1b14a
--> 5ba44f079f60
STEP 7/8: ENV JQ_VERSION="1.7.1"
--> Using cache 8b1f624321dc8ebf8ae663629e6eb8a4c3d89d63dd932ec82ce684ee65a90910
--> 8b1f624321dc
STEP 8/8: RUN curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 &&     chmod +x /usr/local/bin/jq
--> Using cache 0eb53fc58136107b33f6a62c76b647e8dc11b319f1bd4a96f2324cc2e040ed7e
COMMIT quay.io/integreatly/workload-web-app-tools
--> 0eb53fc58136
Successfully tagged quay.io/integreatly/workload-web-app-tools:latest
0eb53fc58136107b33f6a62c76b647e8dc11b319f1bd4a96f2324cc2e040ed7e
podman run --rm -it --privileged -e KUBECONFIG=/kube.config -e RHOAMI= -e GRAFANA_DASHBOARD= -e USERSSO_NAMESPACE= -e THREESCALE_NAMESPACE= -e WORKLOAD_WEB_APP_IMAGE= -v /home/austincunningham/.kube/config:/kube.config:z -v "/home/austincunningham/repo/workload-web-app":/workload-web-app -w /workload-web-app quay.io/integreatly/workload-web-app-tools make deploy
WARN[0000] The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message. 
./deploy/deploy.sh
Now using project "workload-web-app" on server "https://api.austin.lpi0.s1.devshift.org:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app rails-postgresql-example

to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname

namespace/workload-web-app labeled
Error from server (NotFound): routes.route.openshift.io "keycloak-edge" not found
Ignoring missing "keycloak-edge" route and using route "keycloak" instead
secret/rhsso-secret created
3scale.sh: API_URL=https://3scale-admin.apps.austin.lpi0.s1.devshift.org/admin/api
3scale.sh: create workload-app-api-account
3scale.sh: create workload-app-api-backend
3scale.sh: create workload-app-api-metric in backend=3
3scale.sh: create mapping_rule with backend_id=3 and metric_id=9
3scale.sh: create workload-app-api service
3scale.sh: create backend_usage with service_id=3 and backend_id=3
3scale.sh: create workload-app-api-plan in service=3
3scale.sh: create workload-app-api-app in account=4 with plan_id=10
3scale.sh: promote api to staging service_id=3
3scale.sh: promote api to production service_id=3
Waiting for the https://workload-app-api-3scale-apicast-production.apps.austin.lpi0.s1.devshift.org?user_key=1d233c7fdeaf0a0a80ae26f94512a904 to be reachable
Waiting for 3SCALE API to be reachable for 10m...
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
Waiting for 3SCALE API to be reachable... Trying again in 10s
200
3SCALE API to be reachable finished!
Deploying the webapp with the following parameters:
RHSSO_SERVER_URL=https://keycloak-redhat-rhoam-user-sso.apps.austin.lpi0.s1.devshift.org
THREE_SCALE_URL=https://workload-app-api-3scale-apicast-production.apps.austin.lpi0.s1.devshift.org?user_key=1d233c7fdeaf0a0a80ae26f94512a904
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
deploymentconfig.apps.openshift.io/workload-web-app created
service/workload-web-app created
poddisruptionbudget.policy/workload-web-app-pdb created
serviceaccount/workload-web-app created
role.rbac.authorization.k8s.io/workload-web-app created
rolebinding.rbac.authorization.k8s.io/workload-web-app created
servicemonitor.monitoring.rhobs/workload-web-app created
role.rbac.authorization.k8s.io/rhmi-prometheus-k8s created
rolebinding.rbac.authorization.k8s.io/rhmi-prometheus-k8s created
role.rbac.authorization.k8s.io/rhmi-operator created
rolebinding.rbac.authorization.k8s.io/rhmi-operator created
Waiting for pods to be ready
timed out waiting for the condition on pods/workload-web-app-1-qc2zt
timed out waiting for the condition on pods/workload-web-app-1-sbjfp
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Warning: apps.openshift.io/v1 DeploymentRequest is deprecated in v4.14+, unavailable in v4.10000+
deploymentconfig.apps.openshift.io/workload-web-app rolled out
pod/workload-web-app-2-hf9ct condition met
pod/workload-web-app-2-kxl6d condition met
```
- test the uninstall with podman also
```bash
➜  workload-web-app git:(MGDAPI-6953) ✗ CONTAINER_ENGINE=podman make local/undeploy
✓ podman is available
podman build --platform=linux/amd64 -t quay.io/integreatly/workload-web-app-tools -f Dockerfile.tools .
WARN[0000] The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message. 
STEP 1/8: FROM registry.redhat.io/ubi9/ubi:9.4
STEP 2/8: COPY resources/rhit-root-ca.crt /etc/pki/ca-trust/source/anchors/
--> Using cache 50985eeb599462829fe1ad9b598859345adb16987f01e08f3b3c7275544b5bba
--> 50985eeb5994
STEP 3/8: RUN update-ca-trust extract
--> Using cache 1ab35ea324018d1be388c042fac8d3ffd5562fd9127250b68766e05ca0cb58eb
--> 1ab35ea32401
STEP 4/8: RUN dnf install -y make gcc &&     dnf clean all
--> Using cache 162b856aaa791006fed798d8bae2176a1b5adf6ee4a1d3e171bd8040227485c6
--> 162b856aaa79
STEP 5/8: ENV OC_VERSION="4.17.2"
--> Using cache 7df563f82b68689d8511ee1a84a141cb3ec89c6b6ff657e0b29a89a47238c60d
--> 7df563f82b68
STEP 6/8: RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$OC_VERSION/openshift-client-linux.tar.gz | tar -zx &&     mv oc /usr/local/bin
--> Using cache 5ba44f079f60b9b364d6243670a3adce6a1052f9e1e4cb3ba974c2ef9ad1b14a
--> 5ba44f079f60
STEP 7/8: ENV JQ_VERSION="1.7.1"
--> Using cache 8b1f624321dc8ebf8ae663629e6eb8a4c3d89d63dd932ec82ce684ee65a90910
--> 8b1f624321dc
STEP 8/8: RUN curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 &&     chmod +x /usr/local/bin/jq
--> Using cache 0eb53fc58136107b33f6a62c76b647e8dc11b319f1bd4a96f2324cc2e040ed7e
COMMIT quay.io/integreatly/workload-web-app-tools
--> 0eb53fc58136
Successfully tagged quay.io/integreatly/workload-web-app-tools:latest
0eb53fc58136107b33f6a62c76b647e8dc11b319f1bd4a96f2324cc2e040ed7e
podman run --rm -it --privileged -e KUBECONFIG=/kube.config -e RHOAMI= -e GRAFANA_DASHBOARD= -e USERSSO_NAMESPACE= -e THREESCALE_NAMESPACE= -e WORKLOAD_WEB_APP_IMAGE= -v /home/austincunningham/.kube/config:/kube.config:z -v "/home/austincunningham/repo/workload-web-app":/workload-web-app -w /workload-web-app quay.io/integreatly/workload-web-app-tools make undeploy
WARN[0000] The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message. 
./deploy/undeploy.sh
{"message":"Dashboard not found","traceID":""} 
Grafana dashboard completed
 
pod "workload-web-app-2-hf9ct" deleted
pod "workload-web-app-2-kxl6d" deleted
service "workload-web-app" deleted
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
project.project.openshift.io "workload-web-app" deleted
3scale.sh: API_URL=https://3scale-admin.apps.austin.lpi0.s1.devshift.org/admin/api
3scale.sh: delete workload-app-api-account
3scale.sh: delete workload-app-api service
3scale.sh: delete workload-app-api-backend service
```
